### PR TITLE
Make sure "create_datetime" is always visible; hide "Add" button from admin

### DIFF
--- a/django_db_logger/admin.py
+++ b/django_db_logger/admin.py
@@ -34,5 +34,9 @@ class StatusLogAdmin(admin.ModelAdmin):
         )
     create_datetime_format.short_description = 'Created at'
 
+    def has_add_permission(self, request):
+        # Hide "Add" button from admin
+        return False
+
 
 admin.site.register(StatusLog, StatusLogAdmin)

--- a/django_db_logger/admin.py
+++ b/django_db_logger/admin.py
@@ -9,10 +9,11 @@ from .models import StatusLog
 
 
 class StatusLogAdmin(admin.ModelAdmin):
-    list_display = ('colored_msg', 'traceback', 'create_datetime_format')
+    list_display = ('create_datetime_format', 'colored_msg', 'traceback', )
     list_display_links = ('colored_msg', )
     list_filter = ('level', )
     list_per_page = DJANGO_DB_LOGGER_ADMIN_LIST_PER_PAGE
+    readonly_fields = ['logger_name', 'level', 'msg', 'trace', ]
 
     def colored_msg(self, instance):
         if instance.level in [logging.NOTSET, logging.INFO]:
@@ -28,7 +29,9 @@ class StatusLogAdmin(admin.ModelAdmin):
         return format_html('<pre><code>{content}</code></pre>', content=instance.trace if instance.trace else '')
 
     def create_datetime_format(self, instance):
-        return instance.create_datetime.strftime('%Y-%m-%d %X')
+        return format_html(
+            '<span style="white-space: nowrap;">%s</span>' % instance.create_datetime.strftime('%Y-%m-%d %X')
+        )
     create_datetime_format.short_description = 'Created at'
 
 


### PR DESCRIPTION
I moved "create_datetime" to the left to make sure it's not hidden by filters, and removed the "Add" button which seems inappropriate.
Also, I declared all fields as readonly to prevent accidental modifications; you can still remove records, however.

![Screen Shot 2019-10-01 at 10 38 15](https://user-images.githubusercontent.com/299854/65947204-13066b00-e438-11e9-820d-71e958a378de.png)
