### PR TITLE
Changed python 2 import to six for django 3.0 compat (closed #15)

### DIFF
--- a/django_db_logger/models.py
+++ b/django_db_logger/models.py
@@ -1,6 +1,6 @@
 import logging
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
+from six import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
 
 LOG_LEVELS = (

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     url='https://github.com/CiCiUi/django-db-logger',
     author='zhangshine',
     author_email='zhangshine0125@gmail.com',
-    install_requires=['django>=1.6'],
+    install_requires=['django>=1.6', 'six'],
     classifiers=[
         'Environment :: Web Environment',
         'Framework :: Django',


### PR DESCRIPTION
I put the ideas of @donzthefonz from [this post](https://github.com/CiCiUi/django-db-logger/issues/15#issuecomment-623990834) in a PR. Worked for me, what do you think?

Best 
Ronny