### PR TITLE
Adding fix for Django 3.2+ for the default_auto_field

### DIFF
--- a/django_db_logger/apps.py
+++ b/django_db_logger/apps.py
@@ -4,3 +4,5 @@ from django.apps import AppConfig
 class DbLoggerAppConfig(AppConfig):
     name = 'django_db_logger'
     verbose_name = 'Db logging'
+    # Explicitly set default auto field type to avoid migrations in Django 3.2+
+    default_auto_field = 'django.db.models.AutoField'


### PR DESCRIPTION
So in Django 3.2 they added a [warning](https://docs.djangoproject.com/en/3.2/releases/3.2/#customizing-type-of-auto-created-primary-keys) if you haven't specified a field in the model explicitly as the primary key.  This merge request implements the simplest fix for the warning by adding a value for `default_auto_field` to the appconfig.

```
WARNINGS:
django_db_logger.StatusLog: (models.W042) Auto-created primary key used when not defining a primary key type, by default 'django.db.models.AutoField'.
	HINT: Configure the DEFAULT_AUTO_FIELD setting or the DbLoggerAppConfig.default_auto_field attribute to point to a subclass of AutoField, e.g. 'django.db.models.BigAutoField'.
```